### PR TITLE
Fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,5 @@ jobs:
   include:
     - stage: test
     - stage: verify definitions
+      if: type = pull_request
       script: npm run verify-definitions -- $TRAVIS_COMMIT_RANGE


### PR DESCRIPTION
Travis says that build configuration variables are available to
conditional checks, but not the build _environment_.

> Also, environment variables from your build configuration (.travis.yml) and repository settings are available, and can be matched using env(FOO), see below.

> Note that this means conditions do not have access to the build environment

So is TRAVIS_COMMIT_RANGE considered build config or build env? Who
knows!

But the main concern is that TRAVIS_COMMIT_RANGE is blank for the
initial push of a new branch. So let's just disable the verification
build for pushes entirely. (Not optimal, but that's what travis is
forcing us into.)

fixes #42 