### PR TITLE
Remove scripty 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,146 +10,16 @@
       "integrity": "sha512-gzAFKCo+n83ui1SQCwJHfS9rm3DknC9TEjSdFDKCAZoRQVj3qAIRIP9YQ0QiJpsRJGVoDyB18/AXUTF4Q86oiw==",
       "dev": true
     },
-    "async": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
-      "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
-      "dev": true,
-      "requires": {
-        "lodash": "^4.17.10"
-      }
-    },
-    "balanced-match": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
-    },
     "bats": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/bats/-/bats-0.4.2.tgz",
       "integrity": "sha1-gfIiu8uwg9FSiz6IMKbo8xSHbsY=",
       "dev": true
     },
-    "brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
-      "requires": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
     "brew-publish": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/brew-publish/-/brew-publish-2.3.1.tgz",
       "integrity": "sha512-JtitWM9jtnQk2gerUbvpiYJqUPYrvU43Wet1FDm9w81nJJO4BLAeVLUTFWQTQkV7QtE3AVO203R/67NeTMxzVw==",
-      "dev": true
-    },
-    "concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
-    },
-    "fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
-    },
-    "glob": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
-      "dev": true,
-      "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      }
-    },
-    "inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
-      "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
-    "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
-    },
-    "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
-    },
-    "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
-      "requires": {
-        "brace-expansion": "^1.1.7"
-      }
-    },
-    "once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
-      "requires": {
-        "wrappy": "1"
-      }
-    },
-    "path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
-    },
-    "resolve-from": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
-      "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
-      "dev": true
-    },
-    "resolve-pkg": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pkg/-/resolve-pkg-1.0.0.tgz",
-      "integrity": "sha1-4ZoV54rKLhJEYdySsuOUPvk0lNk=",
-      "dev": true,
-      "requires": {
-        "resolve-from": "^2.0.0"
-      }
-    },
-    "scripty": {
-      "version": "2.0.0-0",
-      "resolved": "https://registry.npmjs.org/scripty/-/scripty-2.0.0-0.tgz",
-      "integrity": "sha512-U+6e6B1v7moIDF922Ob0UBpH4EcrBk+Ym/2gBKwvjMQcgrADb3Ly0M2SoAgArve5NKpgL59YInJvut0wT8P/xg==",
-      "dev": true,
-      "requires": {
-        "async": "^2.6.1",
-        "glob": "^7.0.3",
-        "lodash": "^4.8.2",
-        "resolve-pkg": "^1.0.0"
-      }
-    },
-    "wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -20,13 +20,13 @@
     "test": "test"
   },
   "scripts": {
+    "clean": "git clean -f -- share",
     "postinstall": "script/postinstall",
     "posttest": "npm run lint",
     "lint": "git ls-files bin script **/*.*sh | xargs shellcheck",
-    "verify-definitions": "node_modules/@nodenv/node-build-update-defs/script/verify-definitions",
     "scrape-definitions": "nodenv-update-version-defs --nodejs-pre --chakracore-pre --nodejs-nightly --chakracore-nightly -d $PWD/share/node-build/",
     "submit-definitions": "node_modules/@nodenv/node-build-update-defs/script/submit-definitions",
-    "clean": "git clean -f -- share",
+    "verify-definitions": "node_modules/@nodenv/node-build-update-defs/script/verify-definitions",
     "preversion": "script/preversion",
     "postversion": "npm publish",
     "prepublishOnly": "npm run publish:github && npm run publish:brew",

--- a/package.json
+++ b/package.json
@@ -36,8 +36,7 @@
   "devDependencies": {
     "@nodenv/node-build-update-defs": "^2.8.0",
     "bats": "^0.4.2",
-    "brew-publish": "^2.3.1",
-    "scripty": "^2.0.0-0"
+    "brew-publish": "^2.3.1"
   },
   "scripty": {
     "modules": [

--- a/package.json
+++ b/package.json
@@ -23,15 +23,15 @@
     "postinstall": "script/postinstall",
     "posttest": "npm run lint",
     "lint": "git ls-files bin script **/*.*sh | xargs shellcheck",
-    "verify-definitions": "scripty",
+    "verify-definitions": "node_modules/@nodenv/node-build-update-defs/script/verify-definitions",
     "scrape-definitions": "nodenv-update-version-defs --nodejs-pre --chakracore-pre --nodejs-nightly --chakracore-nightly -d $PWD/share/node-build/",
-    "submit-definitions": "scripty",
+    "submit-definitions": "node_modules/@nodenv/node-build-update-defs/script/submit-definitions",
     "clean": "git clean -f -- share",
-    "preversion": "scripty",
+    "preversion": "script/preversion",
     "postversion": "npm publish",
     "prepublishOnly": "npm run publish:github && npm run publish:brew",
     "publish:brew": "brew-publish",
-    "publish:github": "scripty"
+    "publish:github": "script/publish/github"
   },
   "devDependencies": {
     "@nodenv/node-build-update-defs": "^2.8.0",

--- a/package.json
+++ b/package.json
@@ -37,10 +37,5 @@
     "@nodenv/node-build-update-defs": "^2.8.0",
     "bats": "^0.4.2",
     "brew-publish": "^2.3.1"
-  },
-  "scripty": {
-    "modules": [
-      "@nodenv/node-build-update-defs"
-    ]
   }
 }

--- a/script/preversion
+++ b/script/preversion
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 # Usage: script/release-precheck
 #
 # - fetch from origin

--- a/script/publish/github
+++ b/script/publish/github
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 # Usage: script/publish/github <version>
 #
 # - creates a Release on github


### PR DESCRIPTION
I'm a big fan of scripty but we're removing it here.
As a devDependency, it's not possible to rely on scripty to run
pre/post/install scripts. Because of this, some package scripts can
leverage scripty, and some can't; but it's not immediately obvious which
and why. Therefore, I think it's best to remove scripty so it's not
accidentally used in an install-time script.

Scripty should probably be limited to application usage and not
libraries.

(Side benefit, we'll stop getting security notices for all of lodash
which is only a transitive devDep.)