### PR TITLE
Add autoversioning workflow ala node-build

### DIFF
--- a/.github/linters/.checkov.yaml
+++ b/.github/linters/.checkov.yaml
@@ -1,3 +1,0 @@
-# https://github.com/bridgecrewio/checkov#configuration-using-a-config-file
-skip-check:
-  - CKV_GHA_7

--- a/.github/linters/.checkov.yaml
+++ b/.github/linters/.checkov.yaml
@@ -1,0 +1,3 @@
+# https://github.com/bridgecrewio/checkov#configuration-using-a-config-file
+skip-check:
+  - CKV_GHA_7

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -4,7 +4,7 @@ on:
   schedule: [{ cron: "0 10 * * SAT" }] # weekly: https://crontab.guru/#0_10_*_*_SAT
   workflow_dispatch:
     inputs:
-      version:
+      version: # checkov:skip=CKV_GHA_7
         description: "An explicit version (or major|minor|patch) to tag."
         default: ""
         required: false

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -1,0 +1,40 @@
+name: Version Bump
+on:
+  push: { branches: main, paths: "share/node-build/**" }
+  schedule: [{ cron: "0 10 * * SAT" }] # weekly: https://crontab.guru/#0_10_*_*_SAT
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "An explicit version (or major|minor|patch) to tag."
+        default: ""
+        required: false
+        type: string
+
+permissions: { contents: read }
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        with: { egress-policy: audit }
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.BOT_TOKEN }}
+
+      - if: ${{ !inputs.version }}
+        run: |-
+          npm run preversion --silent -- -o -v -- share/node-build || status=$?
+          case "${status:-0}" in
+            0) echo "bump=patch" >> "$GITHUB_ENV";;
+            1) exit 0;; # exit successfully to mask error, but don't release
+            *) exit "$status" ;; # all other error codes are true failures
+          esac
+
+      - if: ${{ inputs.version || env.bump }}
+        run: npm version ${{ inputs.version || env.bump }}
+        env:
+          GIT_AUTHOR_NAME: ${{ vars.NODENV_BOT_NAME }}
+          GIT_AUTHOR_EMAIL: ${{ vars.NODENV_BOT_EMAIL }}
+          GIT_COMMITTER_NAME: ${{ vars.GHA_BOT_NAME }}
+          GIT_COMMITTER_EMAIL: ${{ vars.GHA_BOT_EMAIL }}


### PR DESCRIPTION
Runs pre-version script to detect changes. Runs on pushes to main (matching `share/node-build/*`) and weekly on saturdays. Can also be run manually with an explicit version to release.